### PR TITLE
Fix recursive path urls and Endpoint structure

### DIFF
--- a/pyblitz/__init__.py
+++ b/pyblitz/__init__.py
@@ -1,5 +1,4 @@
 from . import generator
-del generator.createFileFromRoot
 from . import http
 
 try: 

--- a/pyblitz/common/__init__.py
+++ b/pyblitz/common/__init__.py
@@ -1,10 +1,10 @@
-def convertDashesToCamelCase(string: str):
+def _convertDashesToCamelCase(string: str):
     strList = string.split("-")
     firstStr = strList.pop(0)
     return firstStr + "".join(
-        capitalize(strAfterDash)
+        _capitalize(strAfterDash)
         for strAfterDash in strList
     )
 
-def capitalize(string: str):
+def _capitalize(string: str):
     return string[0].upper() + string[1:]

--- a/pyblitz/generator/__init__.py
+++ b/pyblitz/generator/__init__.py
@@ -1,3 +1,3 @@
-from .files import *
+# from .files import *
 from .parser import *
 from .generate import *

--- a/pyblitz/generator/__init__.py
+++ b/pyblitz/generator/__init__.py
@@ -1,3 +1,3 @@
-# from .files import *
+from .files import *
 from .parser import *
 from .generate import *

--- a/pyblitz/generator/files.py
+++ b/pyblitz/generator/files.py
@@ -10,13 +10,17 @@ _moduleInitPath = sys.modules['pyblitz'].__file__
 _moduleRootPath = os.path.normpath(os.path.join(_moduleInitPath, ".."))
 
 
-def readOpenAPIFile(pathToJson):
+def _readOpenAPIFile(pathToJson):
+    """Given the path to a json file, this converts it into a python `dict`"""
     with open(pathToJson) as jsonFile:
         jsonDict = json.load(jsonFile)
     return jsonDict
 
 
-def createFileFromRoot(filePath):
+# TODO: convert to function that creates from env root (or arbitrary file locations;
+#       aka just open() the filePath)
+def _createFileFromRoot(filePath):
+    """This function creates a file relative to the root of the pyblitz package"""
     if filePath[0] == "/":
         # prevents os.path.join treating this as an absolute path
         filePath = filePath[1:]

--- a/pyblitz/generator/parser.py
+++ b/pyblitz/generator/parser.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Iterable
 
-from ..common import convertDashesToCamelCase
+from ..common import _convertDashesToCamelCase
 
 
 class ParseError(Exception):
@@ -9,6 +9,15 @@ class ParseError(Exception):
 
 
 class Parser(ABC):
+    """The base class for all Parsers, providing common functionality and data classes
+    
+    A Parser instance's main use is to `parse(jsonDict)` a dictionary generated from json.
+    Once parsed, the Parser instance provides several properties:
+    - servers -- a list of found Parser.Servers
+    - endpoints -- a list of found Parser.Endpoints
+    - schema -- a list of found Parser.Schema
+    """
+    
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, **kwargs)
         self.__init_called = False
@@ -128,7 +137,7 @@ class Parser(ABC):
         def className(self) -> str:
             if self._className is None:
                 nameNoBraces = self._pathName[1:-1] if self._pathName[0] == "{" else self._pathName
-                casedName = convertDashesToCamelCase(nameNoBraces)
+                casedName = _convertDashesToCamelCase(nameNoBraces)
                 self._className = casedName
             return self._className
 

--- a/pyblitz/generator/parser.py
+++ b/pyblitz/generator/parser.py
@@ -125,13 +125,9 @@ class Parser(ABC):
             return self._pathName
 
         @property
-        def isVariable(self) -> bool:
-            return self._pathName[0] == "{"
-
-        @property
         def className(self) -> str:
             if self._className is None:
-                nameNoBraces = self._pathName[1:-1] if self.isVariable else self._pathName
+                nameNoBraces = self._pathName[1:-1] if self._pathName[0] == "{" else self._pathName
                 casedName = convertDashesToCamelCase(nameNoBraces)
                 self._className = casedName
             return self._className

--- a/pyblitz/http/network.py
+++ b/pyblitz/http/network.py
@@ -10,21 +10,36 @@ class _NetworkState:
 
 
 def registerServer(name, url):
+    """Records data for a server that can later be activated by `setActiveServer(name)`"""
     _NetworkState.servers[name] = url
 
 def getServer(name):
+    """Returns the stored url for a previously registered server"""
     return _NetworkState.servers[name]
 
 def getServerNames():
+    """Returns all previously registered server names"""
     return list(_NetworkState.servers.keys())
 
 def setActiveServer(name):
+    """Sets the active server to use for all future requests.
+    
+    This can be called any number of times at any point while your program is running.
+    Requests will always be made to the server that was last activated by this function.
+    """
+
     if name not in _NetworkState.servers:
         raise ValueError("Server '{}' is not registered!".format(name))
     _NetworkState.activeServer = _NetworkState.servers[name]
 
 
 def setAuth(token):
+    """Sets the authentication token to use for all requests.
+    
+    This can be called any number of times at any point while your program is running.
+    Requests will always use the token that was last recorded by this function.
+    """
+
     _NetworkState.session.headers.update({
         "authorization": "Bearer {}".format(token),
     })
@@ -32,6 +47,7 @@ def setAuth(token):
 
 
 def _authenticated(fn):
+    """A decorator that ensures calls made to an HTTP method are both authenticated and have a target server"""
     def authedFn(*args, **kwargs):
         if _NetworkState.activeServer is None:
             raise RuntimeError("Cannot make network requests until a server is chosen via pyblitz.http.setActiveServer()")


### PR DESCRIPTION
Three specific problems were solved here:
- Path URLs were bugged for endpoints such that variable endpoints (like `users/{user_id}`) did not replace placeholders with the correct path values. This is fixed now.
- A reorganized system is in place to handle different kinds of endpoints. Now, endpoints like `users/{user_id}` are invoked as `api.users(user_idVal)` instead of `api.users.user_id(user_idVal)`.
- Several docstrings and comments were added to improve readability